### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: [ 'v*.*.*' ]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/cjmalloy/jasper-app/security/code-scanning/1](https://github.com/cjmalloy/jasper-app/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's steps, the following permissions are likely needed:
- `contents: read` for accessing the repository's contents.
- `contents: write` for creating releases (used by the `action-electron-builder` step).

The `permissions` block will be added at the root of the workflow, ensuring it applies to all jobs unless overridden by job-specific permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
